### PR TITLE
Updating eslint rules

### DIFF
--- a/Client/.eslintrc.js
+++ b/Client/.eslintrc.js
@@ -1,7 +1,32 @@
 module.exports = {
-    root: true,
-    extends: [
-      'universe/native',
-    ],
-  };
-  
+  env: {
+    browser: true,
+    es2021: true,
+    "react-native/react-native": true,
+  },
+  extends: ["universe/native", "plugin:react/recommended"],
+  overrides: [
+    {
+      env: {
+        node: true,
+      },
+      files: [".eslintrc.{js,cjs}"],
+      parserOptions: {
+        sourceType: "script",
+      },
+    },
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    jsx: true,
+  },
+  plugins: ["@typescript-eslint", "react", "react-native"],
+  rules: {
+    quotes: ["warn", "double"],
+    "react/react-in-jsx-scope": "off",
+    semi: ["warn", "always"],
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
+  },
+};

--- a/Client/.gitignore
+++ b/Client/.gitignore
@@ -33,3 +33,4 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+android

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -18,6 +18,8 @@
         "@types/react": "~18.2.14",
         "eslint": "^8.51.0",
         "eslint-config-universe": "^12.0.0",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-native": "^4.1.0",
         "typescript": "^5.1.3"
       }
     },
@@ -8823,6 +8825,24 @@
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
+    },
+    "node_modules/eslint-plugin-react-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.1.0.tgz",
+      "integrity": "sha512-QLo7rzTBOl43FvVqDdq5Ql9IoElIuTdjrz9SKAXCvULvBoRZ44JGSkx9z4999ZusCsb4rK3gjS8gOGyeYqZv2Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-react-native-globals": "^0.1.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-native-globals": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz",
+      "integrity": "sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==",
+      "dev": true
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -20,6 +20,8 @@
     "@types/react": "~18.2.14",
     "eslint": "^8.51.0",
     "eslint-config-universe": "^12.0.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-native": "^4.1.0",
     "typescript": "^5.1.3"
   },
   "private": true


### PR DESCRIPTION
CLRF rules were strange, prob because of setting up on OSX which uses CL
also got errors for "no unused imports" which should be fixed now, and for some jsx stuff which should also be good now